### PR TITLE
Add PathBase to logged uri. Update to .NET 5

### DIFF
--- a/AspNetCoreRequestTracing.Tests/Server/Startup.cs
+++ b/AspNetCoreRequestTracing.Tests/Server/Startup.cs
@@ -17,7 +17,7 @@ namespace AspNetCoreRequestTracing.Tests.Server
             services.AddMvc();
 #endif
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             services.AddControllers();
 #endif
         }
@@ -28,7 +28,7 @@ namespace AspNetCoreRequestTracing.Tests.Server
 #if NETCOREAPP2_2
             app.UseMvc();
 #endif
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             app.UseRouting();
             app.UseEndpoints(endpoints => endpoints.MapControllers());
 #endif

--- a/AspNetCoreRequestTracing/AspNetCoreRequestTracing.csproj
+++ b/AspNetCoreRequestTracing/AspNetCoreRequestTracing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0;net5.0</TargetFrameworks>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.1.0" Condition="'$(TargetFramework)'=='netcoreapp2.1'" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)'=='netcoreapp3.0'" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework)'=='net5.0'" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.2.2" />
   </ItemGroup>
 

--- a/AspNetCoreRequestTracing/RequestTracingMiddleware.cs
+++ b/AspNetCoreRequestTracing/RequestTracingMiddleware.cs
@@ -62,7 +62,7 @@ namespace AspNetCoreRequestTracing
 #if NETCOREAPP2_1
             context.Request.EnableRewind();
 #endif
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0_OR_GREATER
             context.Request.EnableBuffering();
 #endif
 
@@ -99,7 +99,8 @@ namespace AspNetCoreRequestTracing
             {
                 try
                 {
-                    if (Regex.IsMatch(request.Path, pathMatch))
+                    string path = string.Concat(request.PathBase, request.Path);
+                    if (Regex.IsMatch(path, pathMatch))
                     {
                         return true;
                     }

--- a/AspNetCoreRequestTracing/RequestTracingMiddlewareLoggerExtensions.cs
+++ b/AspNetCoreRequestTracing/RequestTracingMiddlewareLoggerExtensions.cs
@@ -70,7 +70,7 @@ namespace AspNetCoreRequestTracing
             _requestTrace(
                 logger,
                 request.Method,
-                $"{request.Scheme}://{request.Host}{request.Path}{request.QueryString}",
+                $"{request.Scheme}://{request.Host}{request.PathBase}{request.Path}{request.QueryString}",
                 request.Protocol,
                 request.Headers.AllHeadersAsString(),
                 request.Body == null ? string.Empty : await new StreamReader(request.Body).ReadToEndAsync(),


### PR DESCRIPTION
When hosted in IIS in a root path below the server root, or in a virtual directory, PathBase is set.
This was missing in the log before, showing a wrong uri.
See also [stackoverflow](https://stackoverflow.com/questions/58614864/whats-the-difference-between-httprequest-path-and-httprequest-pathbase-in-asp-n).

GitHub Issue: #3

## Proposed Changes
<!-- Please un-comment one ore more that apply to this PR -->

- Bug fix  
  as described in issue #3
- Build or CI related changes  
  Added support for .NET 5

## What is the current behavior?

See issue #3.

## What is the new behavior?

See issue #3.

## Checklist

Please check if your PR fulfills the following requirements:

- [ ] Documentation has been added/updated
- [ ] Automated Unit / Integration tests for the changes have been added/updated
- [x] Contains **NO** breaking changes
- [ ] Updated the Changelog
- [x] Associated with an issue

